### PR TITLE
Use components-form package --Form-message-font-size variable

### DIFF
--- a/packages/components-form/lib/form.css
+++ b/packages/components-form/lib/form.css
@@ -158,7 +158,7 @@
 .Form-message {
   color: var(--Form-message-color);
   display: block;
-  font-size: var(--Form-label-font-size);
+  font-size: var(--Form-message-font-size);
   font-weight: var(--Form-label-font-weight) \9;
   margin: 0;
 }


### PR DESCRIPTION
Make use of `--Form-message-font-size` which is declared and described in docs, but never used.

See: https://github.com/giuseppeg/suitcss-components-form/pull/6
